### PR TITLE
feat: Refactor linear_ramp and introduce RWGChannel

### DIFF
--- a/catseq/ARCHITECTURE.md
+++ b/catseq/ARCHITECTURE.md
@@ -1,0 +1,54 @@
+# Cat-SEQ Framework Architecture
+
+*This document describes the ideal architecture of the `catseq` framework and how it should be used in a concrete experiment. This is based on the design intent as of 2025-08-25.*
+
+The system is divided into two primary components: the **Framework Library** (`catseq`) and the **Experiment Application** (a separate, user-created folder).
+
+---
+
+## Part 1: The `catseq` Framework Library
+
+The `catseq` package is a self-contained, hardware-agnostic library for building categorical sequences. It provides the core engine and a "standard library" of generic components.
+
+### Layer 0: Core Protocols (`catseq/protocols.py`)
+*   **Purpose**: Defines the abstract "language" of the entire system.
+*   **Key Components**: `State`, `Channel`, `HardwareInterface`, etc.
+*   **Dependency Rule**: Has no dependencies on other modules within `catseq`.
+
+### Layer 1: Algebraic Engine (`catseq/model.py`, `catseq/builder.py`)
+*   **Purpose**: Implements the core logic for composing (`@`, `|`) and building morphisms.
+*   **Key Components**: `LaneMorphism`, `MorphismBuilder`.
+*   **Dependency Rule**: Depends only on Layer 0.
+
+### Layer 2: Standard Hardware Vocabulary (`catseq/hardware/`, `catseq/states/`)
+*   **Purpose**: Provides a "batteries-included" set of generic, reusable **definitions** for common hardware types.
+*   **Key Components**: The `TTLDevice` and `RWGDevice` *classes*, and the `TTLState`, `RWGActive` *state definitions*.
+*   **Dependency Rule**: Depends only on Layer 0.
+
+### Layer 3: Standard Morphism API (`catseq/morphisms/`)
+*   **Purpose**: Provides convenient factory functions for the standard hardware types.
+*   **Key Components**: `ttl.pulse`, `rwg.linear_ramp`.
+*   **Dependency Rule**: Depends on all lower-level framework layers.
+
+---
+
+## Part 2: The Experiment Application
+
+This is a separate folder, created by the user, that sits alongside the `catseq` library folder. It uses `catseq` as an imported library.
+
+### `my_experiment/` (Example)
+
+*   **Purpose**: To define a specific machine's physical layout and to build and run experimental sequences.
+*   **Responsibilities**:
+    *   **Channel Instantiation**: This is the primary role. Scripts in this folder will import classes from `catseq.hardware` and create concrete channel **instances**.
+      ```python
+      # In my_experiment/my_machine_setup.py
+      from catseq.hardware.ttl import TTLDevice
+      from catseq.protocols import Channel
+
+      # Defines the specific channels for this experiment
+      TTL_0 = Channel("TTL_0", TTLDevice)
+      PUMP_LASER_TTL = Channel("PUMP_AOM", TTLDevice)
+      ```
+    *   **Sequence Composition**: Scripts will import morphism factories from `catseq.morphisms` and use the instantiated channels to build the final experimental sequence.
+    *   **Execution**: This layer is responsible for taking the final `LaneMorphism` object and passing it to a compiler or hardware driver.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from catseq.protocols import Channel
 from catseq.hardware.ttl import TTLDevice
-from catseq.hardware.rwg import RWGDevice
+from catseq.hardware.rwg import RWGDevice, RWGChannel
 
 # --- Test Fixtures and Dummy Classes ---
 
@@ -21,7 +21,7 @@ class TestRWGDevice(RWGDevice):
 # Concrete Channel instances for use in all tests
 TTL_0 = Channel("TTL_0", TTLDevice)
 TTL_1 = Channel("TTL_1", TTLDevice)
-RWG_0 = Channel("RWG_0", TestRWGDevice)
+RWG_0 = RWGChannel("RWG_0", TestRWGDevice, sbg_ids=(0,))
 
 
 # Fixtures now provide concrete channel instances

--- a/tests/use_cases/test_pgc_cooling.py
+++ b/tests/use_cases/test_pgc_cooling.py
@@ -6,13 +6,14 @@ from catseq.states.common import Uninitialized
 from catseq.states.rwg import RWGReady, RWGActive
 from catseq.morphisms.rwg import initialize, linear_ramp
 from catseq.pending import PENDING
+from catseq.hardware.rwg import RWGChannel
 
 from tests.conftest import TestRWGDevice
 
 # --- Channels ---
 # We use the pre-configured TestRWGDevice from the main conftest
-rwg0 = Channel("RWG0", TestRWGDevice)
-rwg1 = Channel("RWG1", TestRWGDevice)
+rwg0 = RWGChannel("RWG0", TestRWGDevice, sbg_ids=(0,))
+rwg1 = RWGChannel("RWG1", TestRWGDevice, sbg_ids=(1,))
 
 def test_pgc_cooling_use_case():
     """
@@ -53,8 +54,8 @@ def test_pgc_cooling_use_case():
     # Crucially, we do NOT provide start_freq or start_amp, as these will be
     # inferred from the context provided by `initialize_all`.
 
-    ramp_rwg0_def = linear_ramp(duration=20e-6, end_freq=20.0, end_amp=0.5, sbg_id=0)
-    ramp_rwg1_def = linear_ramp(duration=20e-6, end_freq=-5.0, end_amp=0.3, sbg_id=1)
+    ramp_rwg0_def = linear_ramp(duration=20e-6, end_freqs=(20.0,), end_amps=(0.5,))
+    ramp_rwg1_def = linear_ramp(duration=20e-6, end_freqs=(-5.0,), end_amps=(0.3,))
 
     # To create the parallel `pgc_cooling` block, we execute the builders
     # from a PENDING state. This creates concrete but context-independent morphisms.


### PR DESCRIPTION
This commit refactors the `linear_ramp` morphism and introduces a dedicated `RWGChannel` to create a robust, unified API for single- and multi-tone RWG operations, abstracting hardware details away from the morphism layer.

This was the result of an iterative design discussion. The final design prioritizes a pure, hardware-agnostic core `catseq.protocols` module.

Key changes:
- A new `RWGChannel` class is added to `hardware/rwg.py`. This channel is configured with a tuple of `sbg_ids` and its singleton instance is keyed on `(name, sbg_ids)`. This keeps the base `Channel` class in `protocols.py` clean.
- The `linear_ramp` function in `morphisms/rwg.py` is refactored to accept tuples of `end_freqs` and `end_amps`.
- A runtime check within `linear_ramp` ensures that the number of provided frequencies/amplitudes matches the number of SBGs configured in the channel, which must be an `RWGChannel`.
- The entire test suite has been updated to use this new, unified API, and all tests pass.