### PR TITLE
add trace_a and Trace_f to spline_ramp

### DIFF
--- a/catseq/hardware/rwg.py
+++ b/catseq/hardware/rwg.py
@@ -432,7 +432,7 @@ def gen_coeff(start, end, n_knots, T, func):
     return rtmq_params, dur
 
 
-def spline_arbi_func_ramp(targets: List[Optional[StaticWaveform]], duration: float, trace, n_knots:int = 11, ) -> MorphismDef:
+def spline_arbi_func_ramp(targets: List[Optional[StaticWaveform]], duration: float, trace_f=None, trace_a=None, n_knots:int = 11, ) -> MorphismDef:
     """Creates a definition for a cubic ramp with phase continuity.
 
     This ensures smooth start/stop (zero derivative at endpoints is NOT guaranteed;
@@ -482,14 +482,14 @@ def spline_arbi_func_ramp(targets: List[Optional[StaticWaveform]], duration: flo
             duration_us = duration * 1e6
             # --- Frequency: still use linear ramp (or static) ---
             if target_freq != start_freq:
-                freq_coeffs, durs_us = gen_coeff(start_freq, target_freq, n_knots, duration_us, trace)
+                freq_coeffs, durs_us = gen_coeff(start_freq, target_freq, n_knots, duration_us, trace_f if trace_f is not None else lambda x:x)
             else:
                 freq_coeffs = [[start_freq, None, None, None]]* (n_knots-1)
 
             # --- Amplitude: use cubic polynomial in MICROSECONDS ---
             if target_amp != start_amp:
                 # Compute cubic coefficients in SECONDS first
-                amp_coeffs, durs_us = gen_coeff(start_amp, target_amp, n_knots, duration_us, trace)
+                amp_coeffs, durs_us = gen_coeff(start_amp, target_amp, n_knots, duration_us, trace_a if trace_a is not None else lambda x:x)
             else:
                 amp_coeffs = [[start_amp, None, None, None]] * (n_knots-1)
             t_knots = np.linspace(0, duration_us, n_knots)


### PR DESCRIPTION
One can ramp amp and freq on different trajectories with the new func `spline_arbi_func_ramp`.